### PR TITLE
update column to join

### DIFF
--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -34,4 +34,4 @@ FROM
     LEFT JOIN {{ ref('silver__hourly_prices_priority') }}
     p
     ON s.block_timestamp_hour = p.hour
-    AND p.token_address = '0x1::aptos_coin::aptoscoin'
+    AND p.token_address_lower = '0x1::aptos_coin::aptoscoin'

--- a/models/gold/stats/stats__ez_core_metrics_hourly.yml
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.yml
@@ -26,6 +26,8 @@ models:
         description: '{{ doc("total_fees_native") }}'
       - name: TOTAL_FEES_USD
         description: '{{ doc("total_fees_usd") }}'
+        tests:
+          - not_null
       - name: EZ_CORE_METRICS_HOURLY_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP

--- a/models/gold/stats/stats__ez_core_metrics_hourly.yml
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.yml
@@ -27,7 +27,8 @@ models:
       - name: TOTAL_FEES_USD
         description: '{{ doc("total_fees_usd") }}'
         tests:
-          - not_null
+          - not_null:
+              where: block_timestamp_hour > '2022-10-20'
       - name: EZ_CORE_METRICS_HOURLY_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP

--- a/models/silver/stats/silver__core_metrics_hourly.sql
+++ b/models/silver/stats/silver__core_metrics_hourly.sql
@@ -54,7 +54,7 @@ SELECT
     COUNT(
         DISTINCT payload_function
     ) AS unique_payload_function_count,
-    SUM(gas_unit_price * gas_used) AS total_fees,
+    SUM(COALESCE(gas_unit_price,0) * gas_used) AS total_fees,
     -- in Octa = 10^-8 Aptos
     MAX(_inserted_timestamp) AS _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(


### PR DESCRIPTION
- use `token_address_lower` after noticing null values in `total_fees_usd`
- Aptos in `token_address_lower` is the correct `0x1::aptos_coin::aptoscoin`, while in `token_address` it is `0x1::aptos_coin::AptosCoin`
- account for not having price of Aptos and gas_unit_price in early days of chain