### PR TITLE
set sender as swapper

### DIFF
--- a/models/silver/defi/dex/silver__dex_swaps_pancake.sql
+++ b/models/silver/defi/dex/silver__dex_swaps_pancake.sql
@@ -50,7 +50,7 @@ SELECT
     tx_hash,
     event_index,
     event_address,
-    COALESCE(NULLIF(A.event_data :user :: STRING, '0x0'), b.sender) AS swapper,
+    b.sender AS swapper,
     CASE
         WHEN A.event_data :amount_x_in :: INT = 0 THEN TRIM(SPLIT_PART(SPLIT(A.event_type, ',') [1], '>', 1) :: STRING, ' ')
         WHEN A.event_data :amount_x_in :: INT != 0 THEN TRIM(SPLIT_PART(SPLIT(A.event_type, ',') [0], '<', 2) :: STRING, ' ')


### PR DESCRIPTION
Set the tx `sender` as the `swapper` of the dex swap for Pancake
To update: run FR for models/silver/defi/dex/silver__dex_swaps_pancake.sql

- FR run:
```
18:20:42  Finished running 1 incremental model, 6 hooks in 0 hours 1 minutes and 51.86 seconds (111.86s).
18:20:42  
18:20:42  Completed successfully
18:20:42  
18:20:42  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

- Testing for ez_dex_swaps and fact_dex_swaps

```
18:24:54  Finished running 28 tests, 6 hooks in 0 hours 0 minutes and 56.34 seconds (56.34s).
18:24:54  
18:24:54  Completed successfully
18:24:54  
18:24:54  Done. PASS=28 WARN=0 ERROR=0 SKIP=0 TOTAL=28
```