### PR TITLE
deprecate mover bridge

### DIFF
--- a/models/silver/defi/bridge/silver__bridge_combined.sql
+++ b/models/silver/defi/bridge/silver__bridge_combined.sql
@@ -6,7 +6,7 @@
 {% set models = [
     ('a', ref('silver__bridge_celer_transfers')),
     ('a', ref('silver__bridge_layerzero_transfers')),
-    ('a', ref('silver__bridge_mover_transfers')),
+    ('a', ref('silver__bridge_mover_transfers_view')),
     ('a', ref('silver__bridge_wormhole_transfers'))
 ]
  %}

--- a/models/silver/defi/bridge/silver__bridge_mover_transfers.sql
+++ b/models/silver/defi/bridge/silver__bridge_mover_transfers.sql
@@ -5,7 +5,8 @@
     merge_exclude_columns = ["inserted_timestamp"],
     cluster_by = ['block_timestamp::DATE','_inserted_timestamp::DATE'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_hash, version, sender, receiver);",
-    tags = ['noncore']
+    full_refresh = false,
+    enabled = false,
 ) }}
 
 WITH txs AS (

--- a/models/silver/defi/bridge/silver__bridge_mover_transfers_view.sql
+++ b/models/silver/defi/bridge/silver__bridge_mover_transfers_view.sql
@@ -1,0 +1,33 @@
+{{ config(
+  materialized = 'view'
+) }}
+
+SELECT
+    block_number,
+    block_timestamp,
+    version,
+    tx_hash,
+    platform,
+    bridge_address,
+    event_name,
+    direction,
+    tx_sender,
+    sender,
+    receiver,
+    source_chain_id,
+    source_chain_name,
+    destination_chain_id,
+    destination_chain_name,
+    token_address,
+    amount_unadj,
+    event_index,
+    bridge_mover_transfers_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _inserted_timestamp,
+    _invocation_id
+FROM
+  {{ source(
+    'aptos_silver',
+    'bridge_mover_transfers'
+  ) }}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -40,6 +40,9 @@ sources:
       - name: transaction_batch
       - name: blocks_tx_v2
       - name: transaction_batch_v2
-
+  - name: aptos_silver
+    schema: silver
+    tables:
+      - name: bridge_mover_transfers
 
   


### PR DESCRIPTION
Deprecate the `silver.bridge_mover_transfers` table, as Aptos bridging has no longer been occurring on Mover