### PR TITLE
increase test recency bluemove

### DIFF
--- a/models/silver/nft/sales/silver__nft_sales_bluemove_v2.yml
+++ b/models/silver/nft/sales/silver__nft_sales_bluemove_v2.yml
@@ -21,8 +21,8 @@ models:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
           - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: hour
-              interval: 72
+              datepart: day
+              interval: 14
       - name: TX_HASH
         tests:
           - not_null


### PR DESCRIPTION
Update recency test fro bluemove nft sales
- previous 3 day test fails intermittently since there aren't sales every day, but the protocol is still active so will deprecate this table if the 14 day test fails