### PR TITLE
remove recency test

### DIFF
--- a/models/silver/nft/mints/silver__nft_mints_combined.yml
+++ b/models/silver/nft/mints/silver__nft_mints_combined.yml
@@ -20,9 +20,6 @@ models:
               column_type_list:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: hour
-              interval: 72
       - name: TX_HASH
         tests:
           - not_null

--- a/models/silver/nft/mints/silver__nft_mints_v1.yml
+++ b/models/silver/nft/mints/silver__nft_mints_v1.yml
@@ -20,9 +20,6 @@ models:
               column_type_list:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: hour
-              interval: 72
       - name: TX_HASH
         tests:
           - not_null

--- a/models/silver/nft/mints/silver__nft_mints_v2.yml
+++ b/models/silver/nft/mints/silver__nft_mints_v2.yml
@@ -20,9 +20,6 @@ models:
               column_type_list:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: hour
-              interval: 72
       - name: TX_HASH
         tests:
           - not_null


### PR DESCRIPTION
Remove recency test from nft_mints tables
- will deprecate or update the logic in the future depending on plans for aptos curation