### PR TITLE
update logic for fung tokens and aptos token

### DIFF
--- a/models/bronze/prices/bronze__complete_provider_asset_metadata.sql
+++ b/models/bronze/prices/bronze__complete_provider_asset_metadata.sql
@@ -25,7 +25,7 @@ WHERE
     (
         (
             platform ILIKE 'aptos'
-            AND token_address LIKE '%:%'
+            AND token_address ilike '0x%'
         )
         OR (
             platform = 'ethereum'

--- a/models/bronze/prices/bronze__complete_provider_asset_metadata.sql
+++ b/models/bronze/prices/bronze__complete_provider_asset_metadata.sql
@@ -25,7 +25,10 @@ WHERE
     (
         (
             platform ILIKE 'aptos'
-            AND token_address ilike '0x%'
+            AND (
+                token_address LIKE '0x%'
+                OR token_address LIKE '%:%'
+            )
         )
         OR (
             platform = 'ethereum'

--- a/models/bronze/prices/bronze__complete_token_asset_metadata.sql
+++ b/models/bronze/prices/bronze__complete_token_asset_metadata.sql
@@ -26,4 +26,7 @@ FROM
     ) }}
 WHERE
     blockchain ILIKE 'aptos'
-    AND token_address ilike '0x%'
+    AND (
+        token_address LIKE '0x%'
+        OR token_address LIKE '%:%'
+    )

--- a/models/bronze/prices/bronze__complete_token_asset_metadata.sql
+++ b/models/bronze/prices/bronze__complete_token_asset_metadata.sql
@@ -26,4 +26,4 @@ FROM
     ) }}
 WHERE
     blockchain ILIKE 'aptos'
-    AND token_address LIKE '%:%'
+    AND token_address ilike '0x%'

--- a/models/silver/defi/dex/silver__dex_swaps_hyperfluid.sql
+++ b/models/silver/defi/dex/silver__dex_swaps_hyperfluid.sql
@@ -148,8 +148,14 @@ SELECT
     event_index,
     event_address,
     swapper,
-    token_in,
-    token_out,
+    CASE
+        WHEN token_in = '0xa' THEN '0x1::aptos_coin::AptosCoin'
+        ELSE token_in
+    END AS token_in,
+    CASE
+        WHEN token_out = '0xa' THEN '0x1::aptos_coin::AptosCoin'
+        ELSE token_out
+    END AS token_out,
     amount_in_unadj,
     amount_out_unadj,
     {{ dbt_utils.generate_surrogate_key(

--- a/models/silver/defi/dex/silver__dex_swaps_thala_v2.sql
+++ b/models/silver/defi/dex/silver__dex_swaps_thala_v2.sql
@@ -147,8 +147,14 @@ SELECT
     event_index,
     event_address,
     swapper,
-    token_in,
-    token_out,
+    CASE
+        WHEN token_in = '0xa' THEN '0x1::aptos_coin::AptosCoin'
+        ELSE token_in
+    END AS token_in,
+    CASE
+        WHEN token_out = '0xa' THEN '0x1::aptos_coin::AptosCoin'
+        ELSE token_out
+    END AS token_out,
     amount_in_unadj,
     amount_out_unadj,
     {{ dbt_utils.generate_surrogate_key(

--- a/models/silver/price/silver__hourly_prices_priority.sql
+++ b/models/silver/price/silver__hourly_prices_priority.sql
@@ -58,7 +58,7 @@ WHERE
     (
         (
             p.blockchain = 'aptos'
-            AND p.token_address LIKE '%:%'
+            AND p.token_address ilike '0x%'
         )
         OR (
             p.blockchain = 'ethereum'

--- a/models/silver/price/silver__hourly_prices_priority.sql
+++ b/models/silver/price/silver__hourly_prices_priority.sql
@@ -58,7 +58,10 @@ WHERE
     (
         (
             p.blockchain = 'aptos'
-            AND p.token_address ilike '0x%'
+            AND (
+                p.token_address LIKE '0x%'
+                OR p.token_address LIKE '%:%'
+            )
         )
         OR (
             p.blockchain = 'ethereum'


### PR DESCRIPTION
1. update thala and hyperliquid logic to correctly label aptos token transfers
2. update price pipeline filters to include missing fungible tokens which don't have a `:` in the address. Add `0x` filter to remove some junk tokens
- The prices for the missing fungible tokens starts at 2024-12-15 so will have to backfill to then


